### PR TITLE
Adds border config property

### DIFF
--- a/lua/duck.lua
+++ b/lua/duck.lua
@@ -12,13 +12,13 @@ M.ducks_list = {}
 
 ---@type DuckOpts
 local conf = {
-    character="🦆",
-    speed=10,
-    width=2,
-    height=1,
-    color="none",
-    blend=100,
-    border="none"
+    character = "🦆",
+    speed = 10,
+    width = 2,
+    height = 1,
+    color = "none",
+    blend = 100,
+    border = "none"
 }
 
 -- TODO: a mode to wreck the current buffer?
@@ -38,25 +38,25 @@ local waddle = function(duck, speed)
                 col, row = config["col"], config["row"]
             end
 
-            math.randomseed(os.time()*duck)
+            math.randomseed(os.time() * duck)
             local angle = 2 * math.pi * math.random()
             local s = math.sin(angle)
             local c = math.cos(angle)
 
             if row < 0 and s < 0 then
-              row = vim.o.lines
+                row = vim.o.lines
             end
 
-            if row > vim.o.lines  and s > 0 then
-              row = 0
+            if row > vim.o.lines and s > 0 then
+                row = 0
             end
 
             if col < 0 and c < 0 then
-              col = vim.o.columns
+                col = vim.o.columns
             end
 
             if col > vim.o.columns and c > 0 then
-              col = 0
+                col = 0
             end
 
             config["row"] = row + 0.5 * s
@@ -69,13 +69,19 @@ end
 
 M.hatch = function(character, speed, color)
     local buf = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_buf_set_lines(buf , 0, 1, true , {character or conf.character})
+    vim.api.nvim_buf_set_lines(buf, 0, 1, true, {character or conf.character})
 
     local duck = vim.api.nvim_open_win(buf, false, {
-        relative='cursor', style='minimal', row=1, col=1, width=conf.width, height=conf.height, border=conf.border
+        relative = 'cursor',
+        style = 'minimal',
+        row = 1,
+        col = 1,
+        width = conf.width,
+        height = conf.height,
+        border = conf.border,
     })
-    vim.cmd("hi Duck"..duck.." guifg=" .. (color or conf.color) .. " guibg=none blend=" .. conf.blend)
-    vim.api.nvim_win_set_option(duck, 'winhighlight', 'Normal:Duck'..duck)
+    vim.cmd("hi Duck" .. duck .. " guifg=" .. (color or conf.color) .. " guibg=none blend=" .. conf.blend)
+    vim.api.nvim_win_set_option(duck, 'winhighlight', 'Normal:Duck' .. duck)
 
     waddle(duck, speed)
 end

--- a/lua/duck.lua
+++ b/lua/duck.lua
@@ -1,6 +1,25 @@
 local M = {}
 M.ducks_list = {}
-local conf = {character="🦆", speed=10, width=2, height=1, color="none", blend=100}
+
+---@class DuckOpts
+---@field character string
+---@field blend number
+---@field border string
+---@field color string
+---@field height number
+---@field speed number
+---@field width number
+
+---@type DuckOpts
+local conf = {
+    character="🦆",
+    speed=10,
+    width=2,
+    height=1,
+    color="none",
+    blend=100,
+    border="none"
+}
 
 -- TODO: a mode to wreck the current buffer?
 local waddle = function(duck, speed)
@@ -53,7 +72,7 @@ M.hatch = function(character, speed, color)
     vim.api.nvim_buf_set_lines(buf , 0, 1, true , {character or conf.character})
 
     local duck = vim.api.nvim_open_win(buf, false, {
-        relative='cursor', style='minimal', row=1, col=1, width=conf.width, height=conf.height
+        relative='cursor', style='minimal', row=1, col=1, width=conf.width, height=conf.height, border=conf.border
     })
     vim.cmd("hi Duck"..duck.." guifg=" .. (color or conf.color) .. " guibg=none blend=" .. conf.blend)
     vim.api.nvim_win_set_option(duck, 'winhighlight', 'Normal:Duck'..duck)
@@ -88,6 +107,7 @@ M.cook_all = function()
     end
 end
 
+---@param opts DuckOpts
 M.setup = function(opts)
     conf = vim.tbl_deep_extend('force', conf, opts or {})
 end


### PR DESCRIPTION
With the new `vim.opt.winborder` option, all float borders are affected. For me, I have it set up with `"single"`, which made the Duck float a bit ugly 🫤

<img width="359" height="321" alt="Screenshot 2025-11-10 at 09 34 34" src="https://github.com/user-attachments/assets/5464db59-532e-4d7e-968b-6411076ae0ad" />

I imagine this is the same for someone else out there. So I'm just proposing adding a `border` config option so you can reset it.

I'm not sure this needs to be exposed to the consumers via config, or just straight up set it in `nvim_open_win` though. But I see it as less of a breaking change to default it to `none`, and let users handle it however they want.

Open to opinions 🤗

Btw, I absolutely love this plugin 😄 I use it every time I pair program or share my screen 😂